### PR TITLE
refactor: simplify API endpoint URLs and configure Vite proxy

### DIFF
--- a/src/Context/ContextLogin.jsx
+++ b/src/Context/ContextLogin.jsx
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useContext } from 'react';
 import { useCookies } from 'react-cookie'; 
 import { useNavigate } from 'react-router-dom';
-import API_BASE_URL from '../config'; 
 
 const AuthContext = createContext();
 
@@ -19,7 +18,7 @@ export const LoginProvider = ({ children }) => {
     const newUser = { email, password };
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
+      const response = await fetch('/api/v1/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/Context/ContextSignUp.jsx
+++ b/src/Context/ContextSignUp.jsx
@@ -1,6 +1,5 @@
 import React, { createContext, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import API_BASE_URL from '../config'; 
 
 const AuthContext = createContext();
 export const SignUpProvider = ({children})=>{
@@ -13,7 +12,7 @@ export const SignUpProvider = ({children})=>{
         
         const newUser = {email,name,password};
         try{
-            const response = await fetch(`${API_BASE_URL}/api/v1/auth/register`,{
+            const response = await fetch('/api/v1/auth/register',{
                method: 'POST',
                headers: {
                    'Content-Type': 'application/json',

--- a/src/Context/fetchJobs.jsx
+++ b/src/Context/fetchJobs.jsx
@@ -1,6 +1,6 @@
 export const fetchJobs = async (token) => {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/jobs/all`, {
+      const response = await fetch('/api/v1/jobs/all', {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,23 +1,27 @@
 import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, loadEnv } from "vite"
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  // load .env, .env.development, etc.
+  const env = loadEnv(mode, process.cwd())
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-  server: {
-    proxy: {
-      // Proxy API requests to the backend
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,  // now from your .env
+          changeOrigin: true,
+          secure: false,
+        }
       }
     }
   }


### PR DESCRIPTION
Remove hardcoded API_BASE_URL and use relative paths for API endpoints. Update Vite config to load API base URL from environment variables, improving flexibility and maintainability.